### PR TITLE
Use official slideshow API in JavaScript

### DIFF
--- a/app/assets/javascripts/scrollytelling/pageflow/navigation/counter.js
+++ b/app/assets/javascripts/scrollytelling/pageflow/navigation/counter.js
@@ -14,7 +14,7 @@ pageflow.Counter = {
 
   init: function() {
     // Init active dot
-    this.setActive(pageflow.atmo.slideshow.currentPage()[0]);
+    this.setActive(pageflow.slides.currentPage()[0]);
 
     // Listen to page changes
     pageflow.events.on('page:change', this.updateActive.bind(this));
@@ -28,7 +28,7 @@ pageflow.Counter = {
 
     var page_id = $(this).attr('data-page-id');
 
-    pageflow.atmo.slideshow.goToById(page_id);
+    pageflow.slides.goToById(page_id);
   }
 }
 

--- a/app/assets/javascripts/scrollytelling/pageflow/navigation/invert.js
+++ b/app/assets/javascripts/scrollytelling/pageflow/navigation/invert.js
@@ -14,7 +14,7 @@ pageflow.Invert = {
   init: function() {
 
     // Set inverted class on first load
-    this.setInvert(pageflow.atmo.slideshow.currentPage()[0]);
+    this.setInvert(pageflow.slides.currentPage()[0]);
 
     // Listen to page changes
     pageflow.events.on('page:change', this.changeInvert.bind(this));


### PR DESCRIPTION
`pageflow.atmo.slideshow` also happens to be a reference to `pageflow.slides` but is rather an implementation detail of the current atmo audio functionality. Use `pageflow.slides` directly.

Btw, great to see the first third party Pageflow plugin out in the wild! :tada: I've added a link to the [plugins page](https://github.com/codevise/pageflow/wiki/List-of-Plugins#widget-types) in the Pageflow wiki.

Do you mind if I submit one or two more such minor PRs to make the widget type more idiomatic?
