### PR TITLE
place the event hander only on links inside nav

### DIFF
--- a/app/assets/javascripts/scrollytelling/pageflow/navigation/counter.js
+++ b/app/assets/javascripts/scrollytelling/pageflow/navigation/counter.js
@@ -16,7 +16,7 @@ $.widget('scrollytelling.scrollytellingNavigationCounter', {
     pageflow.events.on('page:change', this.updateActive.bind(this));
 
     // Set click handler
-    $('a', this.element).on('click', this.onClick);
+    $('nav a', this.element).on('click', this.onClick);
   },
 
   onClick: function(event) {

--- a/app/views/scrollytelling/pageflow/navigation/_widget.html.erb
+++ b/app/views/scrollytelling/pageflow/navigation/_widget.html.erb
@@ -25,7 +25,6 @@
   <ul class="scrollytelling-home_button scrolly-nav-box">
     <li><%= link_to t('pageflow.scrollytelling_pageflow_navigation.home_link'),
                     entry.home_button.url,
-                    id: 'home-button',
                     title: t('pageflow.scrollytelling_pageflow_navigation.home_title', url: entry.home_button.url) %></li>
   </ul>
   <% end %>


### PR DESCRIPTION
it would bind to all links inside the widget, making normal links
useless! this only needs to happen for navigation links.

/cc @studiorabota